### PR TITLE
1.8.3 Release

### DIFF
--- a/mlw_health_check.php
+++ b/mlw_health_check.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WP Health (Formerly My WP Health Check)
  * Description: Keep your site healthy, secure, and performing well!
- * Version: 1.8.2
+ * Version: 1.8.3
  * Author: Frank Corso
  * Author URI: https://wphealth.app/
  * Plugin URI: https://wphealth.app/
  * Text Domain: my-wp-health-check
  *
  * @author Frank Corso
- * @version 1.8.2
+ * @version 1.8.3
  * @package WPHC
  */
 
@@ -34,7 +34,7 @@ class My_WP_Health_Check {
 	 * @var string
 	 * @since 1.6.0
 	 */
-	public $version = '1.8.2';
+	public $version = '1.8.3';
 
 	/**
 	 * Main construct

--- a/php/class-wphc-checks.php
+++ b/php/class-wphc-checks.php
@@ -409,7 +409,7 @@ class WPHC_Checks {
 		if ( false === $user ) {
 			return $this->prepare_array( "Your site does not have a user 'admin'. Great job!", 'good', 'admin_user', true );
 		} else {
-			return $this->prepare_array( "There is a user 'admin' on your site. Hackers use this username when trying to gain access to your site. Please change this username to something else.", 'good', 'admin_user', false );
+			return $this->prepare_array( "There is a user 'admin' on your site. Hackers use this username when trying to gain access to your site. Please change this username to something else.", 'bad', 'admin_user', false );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: fpcorso
 Tags: php, mysql, plugin, version, security, vulnerable, vulnerability, inactive, update
 Requires at least: 4.7
 Tested up to: 5.2
-Stable tag: 1.8.2
+Stable tag: 1.8.3
 Requires PHP: 5.2
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -95,6 +95,9 @@ WP Health [is on GitHub](https://github.com/fpcorso/wordpress-health-check)!
 1. Admin Page
 
 == Changelog ==
+
+= 1.8.3 (May 16, 2019) =
+* Closed Bug: Failed admin username check shows green ([Issue #112](https://github.com/fpcorso/wordpress-health-check/issues/112))
 
 = 1.8.2 (May 8, 2019) =
 * Ensures compatibility with WordPress 5.2


### PR DESCRIPTION
* Closed Bug: Failed admin username check shows green ([Issue #112](https://github.com/fpcorso/wordpress-health-check/issues/112))