### PR TITLE
Release 1.8.10

### DIFF
--- a/mlw_health_check.php
+++ b/mlw_health_check.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WP Health (Formerly My WP Health Check)
  * Description: Keep your site healthy, secure, and performing well!
- * Version: 1.8.9
+ * Version: 1.8.10
  * Author: Frank Corso
  * Author URI: https://wphealth.app/
  * Plugin URI: https://wphealth.app/
  * Text Domain: my-wp-health-check
  *
  * @author Frank Corso
- * @version 1.8.9
+ * @version 1.8.10
  * @package WPHC
  */
 
@@ -34,7 +34,7 @@ class My_WP_Health_Check {
 	 * @var string
 	 * @since 1.6.0
 	 */
-	public $version = '1.8.9';
+	public $version = '1.8.10';
 
 	/**
 	 * Main construct

--- a/php/class-wphc-checks.php
+++ b/php/class-wphc-checks.php
@@ -75,7 +75,7 @@ class WPHC_Checks {
 		$checks[] = $this->update_plugins_check();
 		$checks[] = $this->inactive_plugins_check();
 		$checks[] = $this->supported_plugin_check( $force, $ignore_limit );
-		$checks[] = $this->vulnerable_plugins_check( $force, $ignore_limit );
+		//$checks[] = $this->vulnerable_plugins_check( $force, $ignore_limit );
 		return apply_filters( 'wphc_plugins_checks', $checks );
 	}
 

--- a/php/class-wphc-checks.php
+++ b/php/class-wphc-checks.php
@@ -616,6 +616,10 @@ class WPHC_Checks {
 				'release' => 'December 6, 2018',
 				'eol'     => 'December 6, 2021',
 			),
+			'7.4' => array(
+				'release' => 'November 28, 2019',
+				'eol'     => 'November 28, 2022',
+			),
 		);
 
 		/**

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fpcorso
 Tags: php, mysql, plugin, version, security, vulnerable, vulnerability, inactive, update
 Requires at least: 4.9
-Tested up to: 5.2.3
+Tested up to: 5.3.2
 Stable tag: 1.8.9
 Requires PHP: 5.2
 License: GPLv2
@@ -95,6 +95,9 @@ WP Health [is on GitHub](https://github.com/fpcorso/wordpress-health-check)!
 1. Admin Page
 
 == Changelog ==
+
+= 1.8.10 (XXX) =
+* Bumps tested WordPress version to recent version
 
 = 1.8.9 (Sept 10, 2019) =
 * Bumps minimum WordPress version to 4.9 which is 2 years old

--- a/readme.txt
+++ b/readme.txt
@@ -97,7 +97,7 @@ WP Health [is on GitHub](https://github.com/fpcorso/wordpress-health-check)!
 == Changelog ==
 
 = 1.8.10 (February 28 , 2020) =
-* Temporarily disables vulnerabilty checker to due changes with 3rd party API
+* Temporarily disables vulnerability checker to due changes with 3rd party API
 * Bumps tested WordPress version to recent version
 
 = 1.8.9 (Sept 10, 2019) =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: fpcorso
 Tags: php, mysql, plugin, version, security, vulnerable, vulnerability, inactive, update
 Requires at least: 4.9
 Tested up to: 5.3.2
-Stable tag: 1.8.9
+Stable tag: 1.8.10
 Requires PHP: 5.2
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -39,9 +39,6 @@ This check ensures that you do not have a user with the username of "admin" on y
 **Plugins No Longer Being Supported**
 This plugin checks to see if you have any plugins installed that are no longer supported by the developer.
 
-**Plugins With Known Vulnerabilities**
-This will check your plugins to see if you have a plugin installed with a known vulnerability that has not been fixed.
-
 **Theme Updates**
 This plugin checks to make sure all of your themes are up to date.
 
@@ -75,6 +72,9 @@ Keep track of how fast your site is loading.
 **Blacklist Monitoring**
 WP Health will monitor dozens of lists and alert you if your site is blacklisted.
 
+**Accessibility Monitoring**
+WP Health will scan your site an alert you of potential accessibility concerns.
+
 **Email Notifications**
 Get notified when a vulnerability is found in a plugin you have installed. Receive summaries for all of your sites.
 
@@ -96,7 +96,8 @@ WP Health [is on GitHub](https://github.com/fpcorso/wordpress-health-check)!
 
 == Changelog ==
 
-= 1.8.10 (XXX) =
+= 1.8.10 (February 28 , 2020) =
+* Temporarily disables vulnerabilty checker to due changes with 3rd party API
 * Bumps tested WordPress version to recent version
 
 = 1.8.9 (Sept 10, 2019) =


### PR DESCRIPTION
* Temporarily disables vulnerability checker to due changes with 3rd party API
* Bumps tested WordPress version to recent version