### PR TITLE
Version 1.8.15

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+= 1.8.15 (Sept 22, 2020) =
+* Bump minimum WordPress version to 5.1, which is 18 months old
+* Fix bug in telemetry opt-in causing multiple requests on sites that opted-in
+
 = 1.8.14 (Sept 6, 2020) =
 * Fix error notice relating to permission callback in REST API
 * Move all api key authentication in REST API to new permission callback

--- a/mlw_health_check.php
+++ b/mlw_health_check.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WP Health (Formerly My WP Health Check)
  * Description: Keep your site healthy, secure, and performing well!
- * Version: 1.8.14
+ * Version: 1.8.15
  * Author: Frank Corso
  * Author URI: https://wphealth.app/
  * Plugin URI: https://wphealth.app/
  * Text Domain: my-wp-health-check
  *
  * @author Frank Corso
- * @version 1.8.14
+ * @version 1.8.15
  * @package WPHC
  */
 
@@ -34,7 +34,7 @@ class My_WP_Health_Check {
 	 * @var string
 	 * @since 1.6.0
 	 */
-	public $version = '1.8.14';
+	public $version = '1.8.15';
 
 	/**
 	 * Main construct

--- a/mlw_health_check.php
+++ b/mlw_health_check.php
@@ -42,6 +42,7 @@ class My_WP_Health_Check {
 	 * @since 0.1.0
 	 */
 	public function __construct() {
+	    $this->maybe_create_scheduled_event();
 		$this->load_dependencies();
 		$this->load_hooks();
 	}
@@ -136,6 +137,17 @@ class My_WP_Health_Check {
 				</tr>
 				<?php
 			}
+		}
+	}
+
+	/**
+	 * Create a weekly cron event, if one does not already exist.
+     *
+     * @since 1.8.15
+	 */
+	public function maybe_create_scheduled_event() {
+		if ( ! wp_next_scheduled( 'wphc_daily_scheduled_action' ) && ! wp_installing() ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', 'wphc_daily_scheduled_action' );
 		}
 	}
 }

--- a/mlw_health_check.php
+++ b/mlw_health_check.php
@@ -57,11 +57,11 @@ class My_WP_Health_Check {
 			include 'php/admin/checks-page.php';
 			include 'php/class-wphc-install.php';
 			include 'php/class-wphc-review-manager.php';
-			include 'php/class-wphc-telemetry.php';
 			include 'php/class-wphc-upsells.php';
 
 			WPHC_Upsells::init();
 		}
+		include 'php/class-wphc-telemetry.php';
 		include 'php/class-wphc-checks.php';
 		include 'php/functions.php';
 		include 'php/ajax.php';

--- a/php/admin/checks-page.php
+++ b/php/admin/checks-page.php
@@ -159,7 +159,7 @@ function wphc_generate_checks_page() {
 						</tr>
 					</tbody>
 				</table>
-				<button class="btn button" id="wphc-settings-save"><?php esc_html_e( 'Save Changes', 'my-wp-health-check' ); ?></button>
+				<button class="btn button button-primary" id="wphc-settings-save"><?php esc_html_e( 'Save Changes', 'my-wp-health-check' ); ?></button>
 			</div>
 		</main>
 	</div>

--- a/php/class-wphc-telemetry.php
+++ b/php/class-wphc-telemetry.php
@@ -114,10 +114,16 @@ class WPHC_Telemetry {
 		$data['db_version']    = $wpdb->db_version();
 		$data['server_app']    = $_SERVER['SERVER_SOFTWARE'];
 
-		// Retrieves current plugin information.
+
+		// Loads in necessary files, if needed.
 		if ( ! function_exists( 'get_plugins' ) ) {
 			include ABSPATH . '/wp-admin/includes/plugin.php';
 		}
+		if ( ! function_exists( 'get_plugin_updates' ) ) {
+			include ABSPATH . '/wp-admin/includes/update.php';
+		}
+
+		// Retrieves current plugin information.
 		$plugins        = array_keys( get_plugins() );
 		$active_plugins = get_option( 'active_plugins', array() );
 		foreach ( $plugins as $key => $plugin ) {

--- a/php/class-wphc-telemetry.php
+++ b/php/class-wphc-telemetry.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sends data to tracking server, if opted in
+ * Sends data to telemetry server, if opted in
  */
 
 // Exits if accessed directly.
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Class To Send Tracking Information
+ * Class To Send Telemetry Information
  *
  * @since 1.2.1
  */
@@ -47,7 +47,7 @@ class WPHC_Telemetry {
 	private function add_hooks() {
 		add_action( 'admin_notices', array( $this, 'admin_notice' ) );
 		add_action( 'admin_init', array( $this, 'admin_notice_check' ) );
-		add_action( 'shutdown', array( $this, 'track_check' ) );
+		add_action( 'wphc_daily_scheduled_action', array( $this, 'telemetry_check' ) );
 	}
 
 	/**
@@ -55,21 +55,21 @@ class WPHC_Telemetry {
 	 *
 	 * Determines if the plugin has been authorized to send the data home in the settings page. Then checks if it has been at least a week since the last send.
 	 *
-	 * @since 1.2.1
+	 * @since 1.8.15
 	 * @uses WPHC_Telemetry::load_data()
 	 * @uses WPHC_Telemetry::send_data()
 	 * @uses WPHC_Telemetry::is_time_to_send()
 	 * @return void
 	 */
-	public function track_check() {
+	public function telemetry_check() {
 		$settings = (array) get_option( 'wphc-settings' );
-		$tracking_allowed = '0';
+		$telemetry_allowed = '0';
 		if ( isset( $settings['tracking_allowed'] ) ) {
-			$tracking_allowed = $settings['tracking_allowed'];
+			$telemetry_allowed = $settings['tracking_allowed'];
 		}
 		$last_time = get_option( 'wphc_tracker_last_time' );
-		if ( $this->is_time_to_send( $tracking_allowed, $last_time ) ) {
-			$this->load_data( $tracking_allowed );
+		if ( $this->is_time_to_send( $telemetry_allowed, $last_time ) ) {
+			$this->load_data();
 			$this->send_data();
 			update_option( 'wphc_tracker_last_time', time() );
 		}
@@ -100,10 +100,9 @@ class WPHC_Telemetry {
 	 * Prepares The Data To Be Sent
 	 *
 	 * @since 1.2.1
-	 * @param string $tracking The value of the tracking setting.
 	 * @return void
 	 */
-	private function load_data( $tracking ) {
+	private function load_data() {
 
 		global $wpdb;
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WP Health (Formerly My WP Health Check) ===
 Contributors: fpcorso
 Tags: php, uptime, plugin, version, security, update
-Requires at least: 4.9
+Requires at least: 5.0
 Tested up to: 5.5
 Stable tag: 1.8.14
 Requires PHP: 5.2
@@ -60,6 +60,12 @@ Check out our premium plans that includes:
 **Central Dashboard**
 See all of your checks from all of your sites in one place!
 
+**Moz Domain Authority Monitoring**
+Monitor changes in your site's Moz Domain Authority.
+
+**Broken Link Monitoring**
+Discover any broken links on your site before your visitors do.
+
 **Broken Images Monitoring**
 Get notified if you have any broken images on your site.
 
@@ -76,12 +82,19 @@ WP Health will monitor dozens of lists and alert you if your site is blacklisted
 WP Health will scan your site an alert you of potential accessibility concerns.
 
 **Email Notifications**
-Get notified when a vulnerability is found in a plugin you have installed. Receive summaries for all of your sites.
+Receive summaries for all your sites including any warnings, broken links, and more!
 
 [Learn more about our premium plan!](https://wphealth.app)
 
 = Make Suggestions Or Contribute =
 WP Health [is on GitHub](https://github.com/fpcorso/wordpress-health-check)!
+
+== Frequently Asked Questions ==
+
+= Why do I need an uptime monitor? =
+You need to keep track of how often your site goes down and be able to immediately look into it. When your site is down, you are missing out on new subscribers and new customers.
+
+Also, if you host guarantees 99% uptime, that could still mean 35 hours where your site is down each year. At 99.9%, that's still over 3 hours your site is down each year. Making sure your hosting provider is staying within their guarantee is important.
 
 == Screenshots ==
 
@@ -123,5 +136,5 @@ For the rest of the changelog, [review our CHANGELOG.MD](https://github.com/fpco
 
 == Upgrade Notice ==
 
-= 1.8.0 =
-This update adds a new check!
+= 1.8.15 =
+Keep WP Health up to date to ensure all of your checks are running smoothly.

--- a/readme.txt
+++ b/readme.txt
@@ -92,7 +92,7 @@ WP Health [is on GitHub](https://github.com/fpcorso/wordpress-health-check)!
 == Frequently Asked Questions ==
 
 = Why do I need an uptime monitor? =
-You need to keep track of how often your site goes down and be able to immediately look into it. When your site is down, you are missing out on new subscribers and new customers.
+If your site were to go down right now, how many visitors and customers would you miss out on until you discovered your site was down? With uptime monitoring, you are immediately notified when your site goes down so you can look into and keep track of how often your site goes down.
 
 Also, if you host guarantees 99% uptime, that could still mean 35 hours where your site is down each year. At 99.9%, that's still over 3 hours your site is down each year. Making sure your hosting provider is staying within their guarantee is important.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === WP Health (Formerly My WP Health Check) ===
 Contributors: fpcorso
 Tags: php, uptime, plugin, version, security, update
-Requires at least: 5.0
+Requires at least: 5.1
 Tested up to: 5.5
-Stable tag: 1.8.14
+Stable tag: 1.8.15
 Requires PHP: 5.2
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -101,6 +101,10 @@ Also, if you host guarantees 99% uptime, that could still mean 35 hours where yo
 1. Admin Page
 
 == Changelog ==
+
+= 1.8.15 (Sept 22, 2020) =
+* Bump minimum WordPress version to 5.1, which is 18 months old
+* Fix bug in telemetry opt-in causing multiple requests on sites that opted-in
 
 = 1.8.14 (Sept 6, 2020) =
 * Fix error notice relating to permission callback in REST API

--- a/uninstall.php
+++ b/uninstall.php
@@ -22,4 +22,8 @@ delete_option( 'wphc_install_timestamp' );
 delete_transient( 'wphc_supported_plugin_check' );
 delete_transient( 'wphc_total_checks' );
 
+// Deletes our daily cron event.
+$timestamp = wp_next_scheduled( 'wphc_daily_scheduled_action' );
+wp_unschedule_event( $timestamp, 'wphc_daily_scheduled_action' );
+
 ?>


### PR DESCRIPTION
* Bump minimum WordPress version to 5.1, which is 18 months old
* Fix bug in telemetry opt-in causing multiple requests on sites that opted-in