### PR TITLE
added ajax nonce (security update)

### DIFF
--- a/js/wphc-admin.js
+++ b/js/wphc-admin.js
@@ -32,7 +32,8 @@ var WPHCAdmin;
 			var data = {
 				action: 'wphc_save_plugin_settings',
 				tracking_allowed: tracking_allowed,
-				api_key: $( '#api_key' ).val(),
+				api_key: $('#api_key').val(),
+				nonce: wphc.ajax_nonce, // our nonce
 			};
 			$.post( ajaxurl, data, function( response ) {
 				response =  JSON.parse( response );

--- a/php/admin/checks-page.php
+++ b/php/admin/checks-page.php
@@ -21,6 +21,10 @@ function wphc_generate_checks_page() {
 	global $my_wp_health_check;
 	wp_enqueue_style( 'wphc-style', plugins_url( '../../css/main.css', __FILE__ ), array(), $my_wp_health_check->version );
 	wp_enqueue_script( 'wphc-admin-script', plugins_url( '../../js/wphc-admin.js', __FILE__ ), array( 'backbone', 'underscore', 'wp-util' ), $my_wp_health_check->version );
+	
+	wp_localize_script('wphc-admin-script', 'wphc', [
+			'ajax_nonce' => wp_create_nonce('wphc-nonce'),
+	]);
 
 	$settings = (array) get_option( 'wphc-settings' );
 	?>

--- a/php/ajax.php
+++ b/php/ajax.php
@@ -56,6 +56,9 @@ add_action( 'wp_ajax_nopriv_wphc_save_plugin_settings', 'wphc_save_settings' );
  * Saves the settings from the "Settings" tab of the plugin
  */
 function wphc_save_settings() {
+	
+	check_ajax_referer('wphc-nonce', 'nonce');
+	
 	$tracking = sanitize_text_field( $_POST['tracking_allowed'] );
 	$api_key  = sanitize_text_field( $_POST['api_key'] );
 	$settings = array(


### PR DESCRIPTION
@tewen Hi!

I've added all the necessary changes to implement the **AJAX nonce check** inside the AJAX handler responsible for saving the settings.

I have provided more details about this here [GitHub Pull Request #178](https://github.com/SiteAlert/sitealert-wordpress-plugin/pull/178#pullrequestreview-1582000821)